### PR TITLE
Implement multi-phase arbitrage engine with mock exchanges

### DIFF
--- a/app/Arbitrage/Adapters/MockBinanceAdapter.php
+++ b/app/Arbitrage/Adapters/MockBinanceAdapter.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Arbitrage\Adapters;
+
+/** Mock adapter emulating Binance spot exchange. */
+class MockBinanceAdapter extends MockExchange
+{
+    public array $fees = ['maker' => 1.0, 'taker' => 1.5]; // bps
+    public array $precision = ['tick' => 0.01, 'step' => 0.001, 'pack' => 0.0001];
+}

--- a/app/Arbitrage/Adapters/MockCoinbaseAdapter.php
+++ b/app/Arbitrage/Adapters/MockCoinbaseAdapter.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Arbitrage\Adapters;
+
+/** Mock adapter emulating Coinbase spot exchange. */
+class MockCoinbaseAdapter extends MockExchange
+{
+    public array $fees = ['maker' => 1.2, 'taker' => 1.8];
+    public array $precision = ['tick' => 0.05, 'step' => 0.0001, 'pack' => 0.01];
+}

--- a/app/Arbitrage/Adapters/MockExchange.php
+++ b/app/Arbitrage/Adapters/MockExchange.php
@@ -1,0 +1,94 @@
+<?php
+namespace App\Arbitrage\Adapters;
+
+use App\Arbitrage\ExchangeAdapter;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * In-memory mock exchange used for tests.
+ */
+class MockExchange implements ExchangeAdapter
+{
+    protected array $orders = [];
+    protected array $fills = [];
+    protected array $transcript = [];
+    protected array $scenarios = [];
+
+    /**
+     * Configure how the next order for a symbol should behave.
+     * Example scenario: ['action' => 'fill', 'qty' => 1.0]
+     */
+    public function setScenario(string $symbol, array $scenario): void
+    {
+        $this->scenarios[$symbol] = $scenario;
+    }
+
+    public function placeOrder(array $order): array
+    {
+        $orderId = (string) Uuid::uuid4();
+        $scenario = $this->scenarios[$order['symbol']] ?? ['action' => 'fill'];
+        $status = 'NEW';
+        $executed = 0.0;
+        if ($scenario['action'] === 'fill') {
+            $status = 'FILLED';
+            $executed = $order['qty'];
+            $this->fills[$orderId][] = [
+                'qty' => $executed,
+                'price' => $order['price'],
+            ];
+        } elseif ($scenario['action'] === 'partial') {
+            $status = 'PARTIALLY_FILLED';
+            $executed = $scenario['qty'];
+            $this->fills[$orderId][] = [
+                'qty' => $executed,
+                'price' => $order['price'],
+            ];
+        } elseif ($scenario['action'] === 'timeout') {
+            // stays NEW until polling times out
+        }
+
+        $this->orders[$orderId] = [
+            'id' => $orderId,
+            'symbol' => $order['symbol'],
+            'side' => $order['side'],
+            'qty' => $order['qty'],
+            'price' => $order['price'],
+            'status' => $status,
+            'executed_qty' => $executed,
+        ];
+
+        $this->transcript[] = ['placeOrder' => $order];
+        return $this->orders[$orderId];
+    }
+
+    public function cancelOrder(string $orderId): array
+    {
+        if (isset($this->orders[$orderId])) {
+            $this->orders[$orderId]['status'] = 'CANCELED';
+        }
+        $this->transcript[] = ['cancelOrder' => $orderId];
+        return $this->orders[$orderId] ?? [];
+    }
+
+    public function getOrder(string $orderId): array
+    {
+        $this->transcript[] = ['getOrder' => $orderId];
+        return $this->orders[$orderId] ?? [];
+    }
+
+    public function getOrderFills(string $orderId): array
+    {
+        $this->transcript[] = ['getOrderFills' => $orderId];
+        return $this->fills[$orderId] ?? [];
+    }
+
+    public function wsSubscribe(string $channel, callable $callback): void
+    {
+        $this->transcript[] = ['wsSubscribe' => $channel];
+    }
+
+    public function getTranscript(): array
+    {
+        return $this->transcript;
+    }
+}

--- a/app/Arbitrage/ArbitrageEngine.php
+++ b/app/Arbitrage/ArbitrageEngine.php
@@ -1,0 +1,154 @@
+<?php
+namespace App\Arbitrage;
+
+use App\Arbitrage\ExchangeAdapter;
+
+/**
+ * Coordinates the multi phase arbitrage flow.
+ *
+ * Sequence Diagram (simplified)
+ * ---------------------------------
+ * A: ingest/validate
+ *    Trader -> Engine : submit signal
+ *    Engine -> Trader : ack/validate
+ * B: account select & reserve
+ *    Engine -> Exchanges : check balances/reserve
+ * C: send & monitor
+ *    Engine -> ExA : placeOrder
+ *    Engine -> ExB : placeOrder
+ *    loop polling/backoff
+ *      Engine -> Ex : getOrder
+ * D: partial/hedge
+ *    alt partial
+ *      Engine -> hedge Ex : placeOrder
+ * E: compute & finalize
+ *    Engine -> Trader : execution report
+ */
+class ArbitrageEngine
+{
+    public function __construct(
+        private ExchangeAdapter $legA,
+        private ExchangeAdapter $legB
+    ) {
+    }
+
+    /** Execute the arbitrage legs. */
+    public function run(array $signal, array $opts = []): array
+    {
+        // ----- Phase A: ingest/validate -----
+        $constraints = $signal['constraints'] ?? [];
+        $maxSlippage = $constraints['Max_slippage_bps'] ?? 0;
+        $minPnl = $constraints['Min_expected_pnl'] ?? 0;
+
+        // ----- Phase B: account select & reserve -----
+        $qty = $this->calcExecutableQty($signal['legs'], $opts);
+
+        // ----- Phase C: send & monitor -----
+        $orders = [];
+        foreach ($signal['legs'] as $i => $leg) {
+            $adapter = $i === 0 ? $this->legA : $this->legB;
+            $tif = $leg['tif'] ?? 'IOC';
+            $qtyRounded = $this->roundQty($qty, $adapter);
+            $orders[$i] = $adapter->placeOrder([
+                'symbol' => $leg['symbol'],
+                'side' => $leg['side'],
+                'qty' => $qtyRounded,
+                'price' => $leg['price'],
+                'tif' => $tif,
+            ]);
+        }
+
+        foreach ($orders as $i => $order) {
+            $adapter = $i === 0 ? $this->legA : $this->legB;
+            $orders[$i] = $this->pollOrder($adapter, $order['id']);
+        }
+
+        // ----- Phase D: partial/hedge -----
+        $execA = $orders[0]['executed_qty'];
+        $execB = $orders[1]['executed_qty'];
+        if (abs($execA - $execB) > 0) {
+            // hedge on exchange with lesser fill
+            if ($execA > $execB) {
+                $adapter = $this->legB;
+                $hedgeQty = $execA - $execB;
+                $adapter->placeOrder([
+                    'symbol' => $signal['legs'][1]['symbol'],
+                    'side' => $signal['legs'][1]['side'],
+                    'qty' => $hedgeQty,
+                    'price' => $signal['legs'][1]['price'],
+                    'tif' => 'IOC',
+                ]);
+            } else {
+                $adapter = $this->legA;
+                $hedgeQty = $execB - $execA;
+                $adapter->placeOrder([
+                    'symbol' => $signal['legs'][0]['symbol'],
+                    'side' => $signal['legs'][0]['side'],
+                    'qty' => $hedgeQty,
+                    'price' => $signal['legs'][0]['price'],
+                    'tif' => 'IOC',
+                ]);
+            }
+        }
+
+        // ----- Phase E: compute & finalize -----
+        $pnl = $this->computePnl($orders, [$this->legA, $this->legB], $signal['legs']);
+        if ($pnl < $minPnl) {
+            return ['status' => 'REJECTED', 'pnl' => $pnl];
+        }
+        return ['status' => 'FILLED', 'pnl' => $pnl];
+    }
+
+    /** qty_exec algorithm - min across balances, constraints, leg qty */
+    private function calcExecutableQty(array $legs, array $opts): float
+    {
+        $balances = $opts['balances'] ?? [100 => PHP_FLOAT_MAX];
+        $riskCap = $opts['risk_cap'] ?? PHP_FLOAT_MAX;
+        $qtys = array_column($legs, 'qty');
+        $qtys[] = $balances[0] ?? PHP_FLOAT_MAX;
+        $qtys[] = $balances[1] ?? PHP_FLOAT_MAX;
+        $qtys[] = $riskCap;
+        return min($qtys);
+    }
+
+    private function roundQty(float $qty, ExchangeAdapter $adapter): float
+    {
+        $p = $adapter->precision ?? ['tick' => 1, 'step' => 1, 'pack' => 1];
+        $qty = floor($qty / $p['step']) * $p['step'];
+        $qty = floor($qty / $p['pack']) * $p['pack'];
+        return $qty;
+    }
+
+    private function pollOrder(ExchangeAdapter $adapter, string $orderId): array
+    {
+        $attempt = 0;
+        $order = $adapter->getOrder($orderId);
+        while (in_array($order['status'], ['NEW', 'PARTIALLY_FILLED'], true) && $attempt < 5) {
+            usleep($this->backoff($attempt) * 1000);
+            $order = $adapter->getOrder($orderId);
+            $attempt++;
+        }
+        if ($order['status'] === 'NEW') {
+            $adapter->cancelOrder($orderId);
+            $order['status'] = 'CANCELED';
+        }
+        return $order;
+    }
+
+    private function backoff(int $attempt, int $base = 100, int $cap = 1000): int
+    {
+        $exp = min($cap, $base * (2 ** $attempt));
+        return random_int(0, $exp);
+    }
+
+    private function computePnl(array $orders, array $adapters, array $legs): float
+    {
+        $qty = min($orders[0]['executed_qty'], $orders[1]['executed_qty']);
+        $buy = $legs[0]['side'] === 'buy' ? 0 : 1;
+        $sell = 1 - $buy;
+        $buyPrice = $legs[$buy]['price'];
+        $sellPrice = $legs[$sell]['price'];
+        $fees = ($adapters[$buy]->fees['taker'] + $adapters[$sell]->fees['taker']) / 10000;
+        return ($sellPrice - $buyPrice) * $qty - $fees * $qty * ($buyPrice + $sellPrice);
+    }
+}

--- a/app/Arbitrage/ExchangeAdapter.php
+++ b/app/Arbitrage/ExchangeAdapter.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Arbitrage;
+
+/**
+ * Exchange abstraction used by the arbitrage engine.
+ */
+interface ExchangeAdapter
+{
+    /**
+     * Place an order on the exchange.
+     *
+     * @param array $order ['symbol'=>string,'side'=>string,'qty'=>float,'price'=>float,'tif'=>string]
+     * @return array ['order_id'=>string,'status'=>string,'executed_qty'=>float,'price'=>float]
+     */
+    public function placeOrder(array $order): array;
+
+    /** Cancel an existing order. */
+    public function cancelOrder(string $orderId): array;
+
+    /** Get order status. */
+    public function getOrder(string $orderId): array;
+
+    /** Get fills for an order. */
+    public function getOrderFills(string $orderId): array;
+
+    /** Subscribe to websocket channel. */
+    public function wsSubscribe(string $channel, callable $callback): void;
+
+    /** Get transcript of interactions for testing. */
+    public function getTranscript(): array;
+}

--- a/tests/Feature/ArbitrageEngineTest.php
+++ b/tests/Feature/ArbitrageEngineTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Tests\Feature;
+
+use App\Arbitrage\Adapters\MockBinanceAdapter;
+use App\Arbitrage\Adapters\MockCoinbaseAdapter;
+use App\Arbitrage\ArbitrageEngine;
+use PHPUnit\Framework\TestCase;
+
+class ArbitrageEngineTest extends TestCase
+{
+    public function test_full_fill_flow(): void
+    {
+        $exA = new MockBinanceAdapter();
+        $exB = new MockCoinbaseAdapter();
+        $engine = new ArbitrageEngine($exA, $exB);
+
+        $signal = [
+            'legs' => [
+                ['symbol' => 'BTCUSDT', 'side' => 'buy', 'qty' => 1, 'price' => 100.0, 'tif' => 'IOC'],
+                ['symbol' => 'BTCUSDT', 'side' => 'sell', 'qty' => 1, 'price' => 101.0, 'tif' => 'IOC'],
+            ],
+        ];
+
+        $report = $engine->run($signal);
+        $this->assertSame('FILLED', $report['status']);
+        $this->assertGreaterThan(0, $report['pnl']);
+        $this->assertNotEmpty($exA->getTranscript());
+    }
+
+    public function test_timeout_causes_cancel(): void
+    {
+        $exA = new MockBinanceAdapter();
+        $exB = new MockCoinbaseAdapter();
+        $exA->setScenario('BTCUSDT', ['action' => 'timeout']);
+        $engine = new ArbitrageEngine($exA, $exB);
+
+        $signal = [
+            'legs' => [
+                ['symbol' => 'BTCUSDT', 'side' => 'buy', 'qty' => 1, 'price' => 100.0],
+                ['symbol' => 'BTCUSDT', 'side' => 'sell', 'qty' => 1, 'price' => 101.0],
+            ],
+        ];
+
+        $report = $engine->run($signal);
+        $trans = $exA->getTranscript();
+        $found = false;
+        foreach ($trans as $t) {
+            if (isset($t['cancelOrder'])) {
+                $found = true;
+            }
+        }
+        $this->assertTrue($found);
+        $this->assertSame('FILLED', $report['status']);
+    }
+
+    public function test_partial_fill_triggers_hedge(): void
+    {
+        $exA = new MockBinanceAdapter();
+        $exB = new MockCoinbaseAdapter();
+        $exA->setScenario('BTCUSDT', ['action' => 'partial', 'qty' => 0.4]);
+        $engine = new ArbitrageEngine($exA, $exB);
+
+        $signal = [
+            'legs' => [
+                ['symbol' => 'BTCUSDT', 'side' => 'buy', 'qty' => 1, 'price' => 100.0],
+                ['symbol' => 'BTCUSDT', 'side' => 'sell', 'qty' => 1, 'price' => 101.0],
+            ],
+        ];
+
+        $engine->run($signal);
+        $transcript = $exB->getTranscript();
+        $this->assertGreaterThan(1, count($transcript)); // hedge order added
+    }
+}


### PR DESCRIPTION
## Summary
- introduce ExchangeAdapter abstraction with mock Binance and Coinbase adapters
- implement `ArbitrageEngine` coordinating ingest/validate → reserve → send/monitor → hedge → finalize
- add integration tests simulating full fills, timeouts with cancel, and partial hedging including replayable transcripts

## Testing
- `vendor/bin/phpunit tests/Feature/ArbitrageEngineTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68b9c68320b4832b9cfdbab0b5aa349c