### PR TITLE
feat: add preflight pnl check

### DIFF
--- a/app/Services/Preflight.php
+++ b/app/Services/Preflight.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services;
+
+class Preflight
+{
+    public function __construct(
+        private int $feeBps,
+        private int $slippageBps
+    ) {}
+
+    public function expectedNetPnl(array $legs, float $execQty): float
+    {
+        $buyPrice = $legs['buy'];
+        $sellPrice = $legs['sell'];
+        $gross = ($sellPrice - $buyPrice) * $execQty;
+        $feeCost = ($buyPrice * $execQty + $sellPrice * $execQty) * $this->feeBps / 10000;
+        return $gross - $feeCost;
+    }
+
+    public function expectedNetPnlWithSlippage(array $legs, float $execQty): float
+    {
+        $buyPrice = $legs['buy'] * (1 + $this->slippageBps / 10000);
+        $sellPrice = $legs['sell'] * (1 - $this->slippageBps / 10000);
+        $gross = ($sellPrice - $buyPrice) * $execQty;
+        $feeCost = ($buyPrice * $execQty + $sellPrice * $execQty) * $this->feeBps / 10000;
+        return $gross - $feeCost;
+    }
+
+    public function passesMinPnl(float $pnlWithBuffers, float $minExpected): bool
+    {
+        return $pnlWithBuffers >= $minExpected;
+    }
+}

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Preflight;
+use PHPUnit\Framework\TestCase;
+
+class PreflightTest extends TestCase
+{
+    public function test_expected_pnl_and_min_pnl_rejection(): void
+    {
+        $service = new Preflight(feeBps: 10, slippageBps: 10);
+        $legs = ['buy' => 1_000_000, 'sell' => 1_010_000];
+        $execQty = 5119; // derived effective quantity
+
+        $pnlBefore = $service->expectedNetPnl($legs, $execQty);
+        $this->assertEqualsWithDelta(40_899_000, $pnlBefore, 2_000, 'PNL before buffers should match example');
+
+        $pnlAfter = $service->expectedNetPnlWithSlippage($legs, $execQty);
+        $this->assertFalse($service->passesMinPnl($pnlAfter, 35_000_000));
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple Preflight service to compute expected PnL with optional slippage
- add unit test validating USDT/IRR example and min PnL rejection

## Testing
- `php artisan test` *(fails: MissingAppKeyException; signal persistence fails due to DB constraint)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca985a04832b87e70b24ba305209