### PR TITLE
Add orchestrator command for processing arbitrage signals

### DIFF
--- a/app/Console/Commands/ProcessSignals.php
+++ b/app/Console/Commands/ProcessSignals.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Signal;
+use App\Models\PairExchange;
+use App\Services\Preflight;
+use App\Arbitrage\ArbitrageEngine;
+use App\Arbitrage\Adapters\MockBinanceAdapter;
+use App\Arbitrage\Adapters\MockCoinbaseAdapter;
+
+class ProcessSignals extends Command
+{
+    protected $signature = 'signals:process';
+
+    protected $description = 'Process pending arbitrage signals';
+
+    public function handle(): int
+    {
+        $signals = Signal::with('legs')->where('status', 'PENDING')->get();
+
+        foreach ($signals as $signal) {
+            $buyLeg = $signal->legs->firstWhere('side', 'buy');
+            $sellLeg = $signal->legs->firstWhere('side', 'sell');
+            if (!$buyLeg || !$sellLeg) {
+                $signal->update(['status' => 'REJECTED']);
+                continue;
+            }
+
+            $buyPx = PairExchange::whereHas('exchange', fn($q) => $q->where('name', $buyLeg->exchange))
+                ->whereHas('pair', fn($q) => $q->where('symbol', $buyLeg->market))
+                ->first();
+            $sellPx = PairExchange::whereHas('exchange', fn($q) => $q->where('name', $sellLeg->exchange))
+                ->whereHas('pair', fn($q) => $q->where('symbol', $sellLeg->market))
+                ->first();
+            if (!$buyPx || !$sellPx) {
+                $signal->update(['status' => 'REJECTED']);
+                continue;
+            }
+
+            $preflight = new Preflight(
+                feeBps: ['buy' => $buyPx->taker_fee_bps ?? 0, 'sell' => $sellPx->taker_fee_bps ?? 0],
+                slippageBps: ['buy' => $buyPx->slippage_bps ?? 0, 'sell' => $sellPx->slippage_bps ?? 0]
+            );
+
+            $execQty = min($buyLeg->qty, $sellLeg->qty);
+            $pnl = $preflight->expectedNetPnlWithSlippage([
+                'buy' => $buyLeg->price,
+                'sell' => $sellLeg->price,
+            ], $execQty);
+            $min = $signal->constraints['Min_expected_pnl'] ?? 0;
+            if (!$preflight->passesMinPnl($pnl, $min)) {
+                $signal->update(['status' => 'REJECTED', 'expected_pnl' => $pnl]);
+                $this->info("Signal {$signal->id} rejected");
+                continue;
+            }
+
+            $engine = new ArbitrageEngine(new MockBinanceAdapter(), new MockCoinbaseAdapter());
+            $payload = [
+                'constraints' => $signal->constraints ?? [],
+                'legs' => $signal->legs->map(fn($leg) => [
+                    'symbol' => $leg->market,
+                    'side' => $leg->side,
+                    'price' => (float) $leg->price,
+                    'qty' => (float) $leg->qty,
+                    'tif' => $leg->time_in_force,
+                ])->toArray(),
+            ];
+            $report = $engine->run($payload);
+            $signal->update(['status' => $report['status'], 'expected_pnl' => $report['pnl']]);
+            $this->info("Signal {$signal->id} {$report['status']}");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/SignalController.php
+++ b/app/Http/Controllers/SignalController.php
@@ -40,10 +40,11 @@ class SignalController extends Controller
         DB::transaction(function () use ($data) {
             $signal = Signal::create([
                 'id' => $data['signal_id'],
-                'signal_created_at' => $data['created_at'],
+                'created_at' => $data['created_at'],
                 'ttl_ms' => $data['ttl_ms'],
                 'constraints' => $data['constraints'] ?? null,
-                'state' => 'PENDING',
+                'status' => 'PENDING',
+                'source' => 'api',
             ]);
 
             foreach ($data['legs'] as $leg) {
@@ -51,7 +52,7 @@ class SignalController extends Controller
                     'signal_id' => $signal->id,
                     'exchange' => $leg['Exchange'],
                     'market' => $leg['market'],
-                    'side' => $leg['Side'],
+                    'side' => strtolower($leg['Side']),
                     'price' => $leg['Price'],
                     'qty' => $leg['Qty'],
                     'time_in_force' => $leg['time_in_force'],

--- a/app/Models/PairExchange.php
+++ b/app/Models/PairExchange.php
@@ -20,6 +20,7 @@ class PairExchange extends Model
         'pack_size',
         'maker_fee_bps',
         'taker_fee_bps',
+        'slippage_bps',
         'status',
     ];
 

--- a/app/Models/SignalLeg.php
+++ b/app/Models/SignalLeg.php
@@ -11,13 +11,12 @@ class SignalLeg extends Model
 
     protected $fillable = [
         'signal_id',
-        'exchange_id',
-        'pair_id',
+        'exchange',
+        'market',
         'side',
         'price',
         'qty',
-        'tif',
-        'desired_role',
+        'time_in_force',
     ];
 
     protected $casts = [
@@ -30,13 +29,5 @@ class SignalLeg extends Model
         return $this->belongsTo(Signal::class);
     }
 
-    public function exchange(): BelongsTo
-    {
-        return $this->belongsTo(Exchange::class);
-    }
-
-    public function pair(): BelongsTo
-    {
-        return $this->belongsTo(Pair::class);
-    }
+    // Relations to Exchange and Pair removed for simplified schema
 }

--- a/app/Services/Preflight.php
+++ b/app/Services/Preflight.php
@@ -5,8 +5,8 @@ namespace App\Services;
 class Preflight
 {
     public function __construct(
-        private int $feeBps,
-        private int $slippageBps
+        private array $feeBps,
+        private array $slippageBps
     ) {}
 
     public function expectedNetPnl(array $legs, float $execQty): float
@@ -14,16 +14,18 @@ class Preflight
         $buyPrice = $legs['buy'];
         $sellPrice = $legs['sell'];
         $gross = ($sellPrice - $buyPrice) * $execQty;
-        $feeCost = ($buyPrice * $execQty + $sellPrice * $execQty) * $this->feeBps / 10000;
+        $feeCost = ($buyPrice * $execQty * ($this->feeBps['buy'] ?? 0) / 10000)
+            + ($sellPrice * $execQty * ($this->feeBps['sell'] ?? 0) / 10000);
         return $gross - $feeCost;
     }
 
     public function expectedNetPnlWithSlippage(array $legs, float $execQty): float
     {
-        $buyPrice = $legs['buy'] * (1 + $this->slippageBps / 10000);
-        $sellPrice = $legs['sell'] * (1 - $this->slippageBps / 10000);
+        $buyPrice = $legs['buy'] * (1 + ($this->slippageBps['buy'] ?? 0) / 10000);
+        $sellPrice = $legs['sell'] * (1 - ($this->slippageBps['sell'] ?? 0) / 10000);
         $gross = ($sellPrice - $buyPrice) * $execQty;
-        $feeCost = ($buyPrice * $execQty + $sellPrice * $execQty) * $this->feeBps / 10000;
+        $feeCost = ($buyPrice * $execQty * ($this->feeBps['buy'] ?? 0) / 10000)
+            + ($sellPrice * $execQty * ($this->feeBps['sell'] ?? 0) / 10000);
         return $gross - $feeCost;
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Console\Commands\ProcessSignals;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -16,4 +17,8 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //
-    })->create();
+    })
+    ->withCommands([
+        ProcessSignals::class,
+    ])
+    ->create();

--- a/database/migrations/2025_09_04_162520_create_signal_legs_table.php
+++ b/database/migrations/2025_09_04_162520_create_signal_legs_table.php
@@ -14,17 +14,14 @@ return new class extends Migration
         Schema::create('signal_legs', function (Blueprint $table) {
             $table->id();
             $table->uuid('signal_id');
-            $table->foreignId('exchange_id')->constrained('exchanges');
-            $table->foreignId('pair_id')->constrained('pairs');
+            $table->string('exchange');
+            $table->string('market');
             $table->string('side');
             $table->decimal('price', 24, 8);
             $table->decimal('qty', 24, 8);
-            $table->string('tif');
-            $table->string('desired_role');
+            $table->string('time_in_force');
 
             $table->foreign('signal_id')->references('id')->on('signals')->cascadeOnDelete();
-            $table->index('exchange_id');
-            $table->index('pair_id');
             $table->index('signal_id');
         });
     }

--- a/database/migrations/2025_09_04_162526_create_pair_exchanges_table.php
+++ b/database/migrations/2025_09_04_162526_create_pair_exchanges_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->decimal('pack_size', 24, 8)->nullable();
             $table->unsignedInteger('maker_fee_bps')->nullable();
             $table->unsignedInteger('taker_fee_bps')->nullable();
+            $table->unsignedInteger('slippage_bps')->nullable();
             $table->string('status');
 
             $table->unique(['exchange_id', 'pair_id']);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
         </include>
     </source>
     <php>
+        <env name="APP_KEY" value="base64:qtjdhZyC3/1unFPWeWSII7QJ+fFFkBp6FExUUrxxmUg="/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/tests/Feature/ProcessSignalsCommandTest.php
+++ b/tests/Feature/ProcessSignalsCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use App\Models\Signal;
+use App\Models\SignalLeg;
+use App\Models\Exchange;
+use App\Models\Currency;
+use App\Models\Pair;
+use App\Models\PairExchange;
+
+class ProcessSignalsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pending_signal_is_executed(): void
+    {
+        $exA = Exchange::create(['name' => 'exA', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $exB = Exchange::create(['name' => 'exB', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $usdt = Currency::create(['symbol' => 'USDT', 'name' => 'Tether']);
+        $irr = Currency::create(['symbol' => 'IRR', 'name' => 'Rial']);
+        $pair = Pair::create(['base_currency_id' => $usdt->id, 'quote_currency_id' => $irr->id, 'symbol' => 'USDT/IRR']);
+        PairExchange::create([
+            'exchange_id' => $exA->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 5,
+            'taker_fee_bps' => 7,
+            'slippage_bps' => 1,
+            'status' => 'ACTIVE',
+        ]);
+        PairExchange::create([
+            'exchange_id' => $exB->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 6,
+            'taker_fee_bps' => 8,
+            'slippage_bps' => 2,
+            'status' => 'ACTIVE',
+        ]);
+
+        $signal = Signal::create([
+            'id' => (string) Str::uuid(),
+            'ttl_ms' => 5000,
+            'status' => 'PENDING',
+            'source' => 'api',
+            'constraints' => ['Min_expected_pnl' => 0],
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exA',
+            'market' => 'USDT/IRR',
+            'side' => 'buy',
+            'price' => 1000000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exB',
+            'market' => 'USDT/IRR',
+            'side' => 'sell',
+            'price' => 1010000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        $this->artisan('signals:process')->assertExitCode(0);
+
+        $signal->refresh();
+        $this->assertSame('FILLED', $signal->status);
+        $this->assertNotNull($signal->expected_pnl);
+    }
+}

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -9,7 +9,7 @@ class PreflightTest extends TestCase
 {
     public function test_expected_pnl_and_min_pnl_rejection(): void
     {
-        $service = new Preflight(feeBps: 10, slippageBps: 10);
+        $service = new Preflight(feeBps: ['buy' => 10, 'sell' => 10], slippageBps: ['buy' => 10, 'sell' => 10]);
         $legs = ['buy' => 1_000_000, 'sell' => 1_010_000];
         $execQty = 5119; // derived effective quantity
 


### PR DESCRIPTION
## Summary
- Add `signals:process` command to pull pending signals, run preflight checks, and execute through ArbitrageEngine
- Register command in the application bootstrap
- Normalize signal storage schema and controller to support pending status and legs
- Cover signal processing flow with feature test
- Pull per-leg fee and slippage data from pair exchanges during preflight
- Allow Preflight service to handle per-leg fee and slippage values

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bade0d0a0c832bbf2b9400902ad5ce