### PR TITLE
Add notional caps and volatility guards in preflight

### DIFF
--- a/app/Services/Preflight.php
+++ b/app/Services/Preflight.php
@@ -16,6 +16,7 @@ class Preflight
         $gross = ($sellPrice - $buyPrice) * $execQty;
         $feeCost = ($buyPrice * $execQty * ($this->feeBps['buy'] ?? 0) / 10000)
             + ($sellPrice * $execQty * ($this->feeBps['sell'] ?? 0) / 10000);
+
         return $gross - $feeCost;
     }
 
@@ -26,11 +27,56 @@ class Preflight
         $gross = ($sellPrice - $buyPrice) * $execQty;
         $feeCost = ($buyPrice * $execQty * ($this->feeBps['buy'] ?? 0) / 10000)
             + ($sellPrice * $execQty * ($this->feeBps['sell'] ?? 0) / 10000);
+
         return $gross - $feeCost;
     }
 
     public function passesMinPnl(float $pnlWithBuffers, float $minExpected): bool
     {
         return $pnlWithBuffers >= $minExpected;
+    }
+
+    public function passesPortfolioCap(float $notional, float $cap): bool
+    {
+        if ($cap <= 0) {
+            return true;
+        }
+
+        return $notional <= $cap;
+    }
+
+    /**
+     * @param  array<string,float>  $caps  keyed by exchange name
+     */
+    public function passesExchangeLimit(string $exchange, float $notional, array $caps): bool
+    {
+        $cap = $caps[$exchange] ?? 0;
+        if ($cap <= 0) {
+            return true;
+        }
+
+        return $notional <= $cap;
+    }
+
+    /**
+     * @param  array<string,float>  $caps  keyed by market symbol
+     */
+    public function passesMarketLimit(string $market, float $notional, array $caps): bool
+    {
+        $cap = $caps[$market] ?? 0;
+        if ($cap <= 0) {
+            return true;
+        }
+
+        return $notional <= $cap;
+    }
+
+    public function passesVolatilityGuard(float $pctMove, float $threshold): bool
+    {
+        if ($threshold <= 0) {
+            return true;
+        }
+
+        return abs($pctMove) <= $threshold;
     }
 }

--- a/tests/Feature/ProcessSignalJobTest.php
+++ b/tests/Feature/ProcessSignalJobTest.php
@@ -2,19 +2,19 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
-use Tests\TestCase;
-use App\Models\Signal;
-use App\Models\SignalLeg;
-use App\Models\Exchange;
-use App\Models\Currency;
-use App\Models\Pair;
-use App\Models\PairExchange;
-use App\Jobs\ProcessSignalJob;
 use App\Arbitrage\Adapters\ExchangeAdapterFactory;
 use App\Arbitrage\Adapters\MockBinanceAdapter;
 use App\Arbitrage\Adapters\MockCoinbaseAdapter;
+use App\Jobs\ProcessSignalJob;
+use App\Models\Currency;
+use App\Models\Exchange;
+use App\Models\Pair;
+use App\Models\PairExchange;
+use App\Models\Signal;
+use App\Models\SignalLeg;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
 
 class ProcessSignalJobTest extends TestCase
 {
@@ -163,6 +163,86 @@ class ProcessSignalJobTest extends TestCase
         return [
             ['exA', 'exB', MockBinanceAdapter::class, MockCoinbaseAdapter::class],
             ['exB', 'exA', MockCoinbaseAdapter::class, MockBinanceAdapter::class],
+        ];
+    }
+
+    /**
+     * @dataProvider riskFailureConstraints
+     */
+    public function test_signal_rejected_when_risk_checks_fail(array $constraints): void
+    {
+        ExchangeAdapterFactory::reset();
+        $exA = Exchange::create(['name' => 'exA', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $exB = Exchange::create(['name' => 'exB', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $usdt = Currency::create(['symbol' => 'USDT', 'name' => 'Tether']);
+        $irr = Currency::create(['symbol' => 'IRR', 'name' => 'Rial']);
+        $pair = Pair::create(['base_currency_id' => $usdt->id, 'quote_currency_id' => $irr->id, 'symbol' => 'USDT/IRR']);
+        PairExchange::create([
+            'exchange_id' => $exA->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 5,
+            'taker_fee_bps' => 7,
+            'slippage_bps' => 1,
+            'status' => 'ACTIVE',
+        ]);
+        PairExchange::create([
+            'exchange_id' => $exB->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 6,
+            'taker_fee_bps' => 8,
+            'slippage_bps' => 2,
+            'status' => 'ACTIVE',
+        ]);
+
+        $signal = Signal::create([
+            'id' => (string) Str::uuid(),
+            'ttl_ms' => 5000,
+            'status' => 'PENDING',
+            'source' => 'api',
+            'constraints' => $constraints,
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exA',
+            'market' => 'USDT/IRR',
+            'side' => 'buy',
+            'price' => 1000000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exB',
+            'market' => 'USDT/IRR',
+            'side' => 'sell',
+            'price' => 1010000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        ProcessSignalJob::dispatchSync($signal->id);
+
+        $signal->refresh();
+        $this->assertSame('REJECTED', $signal->status);
+    }
+
+    public static function riskFailureConstraints(): array
+    {
+        return [
+            'portfolio' => [['Min_expected_pnl' => 0, 'Max_portfolio_notional' => 1]],
+            'exchange' => [['Min_expected_pnl' => 0, 'Max_portfolio_notional' => 1e12, 'Exchange_notional_caps' => ['exA' => 1]]],
+            'market' => [['Min_expected_pnl' => 0, 'Max_portfolio_notional' => 1e12, 'Market_notional_caps' => ['USDT/IRR' => 1]]],
+            'volatility' => [['Min_expected_pnl' => 0, 'Max_portfolio_notional' => 1e12, 'Max_price_move_pct' => 0.5]],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add preflight checks for portfolio, exchange, and market notionals
- add volatility guard to block trades after large price moves
- enforce new risk checks in ProcessSignalJob
- cover risk rejections with tests

## Testing
- `vendor/bin/pint app/Services/Preflight.php app/Jobs/ProcessSignalJob.php tests/Feature/ProcessSignalJobTest.php`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bc421a8728832b8f422c24f0ce25a3