### PR TITLE
feat: enforce market constraints in preflight

### DIFF
--- a/app/Services/Preflight.php
+++ b/app/Services/Preflight.php
@@ -74,7 +74,7 @@ class Preflight
     private function roundPrice(float $price, ?float $tickSize): float
     {
         return ($tickSize && $tickSize > 0)
-            ? round($price / $tickSize) * $tickSize
+            ? floor($price / $tickSize) * $tickSize
             : $price;
     }
 }

--- a/app/Services/Preflight.php
+++ b/app/Services/Preflight.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use InvalidArgumentException;
+
 class Preflight
 {
     public function __construct(
@@ -16,6 +18,7 @@ class Preflight
         $gross = ($sellPrice - $buyPrice) * $execQty;
         $feeCost = ($buyPrice * $execQty * ($this->feeBps['buy'] ?? 0) / 10000)
             + ($sellPrice * $execQty * ($this->feeBps['sell'] ?? 0) / 10000);
+
         return $gross - $feeCost;
     }
 
@@ -26,11 +29,52 @@ class Preflight
         $gross = ($sellPrice - $buyPrice) * $execQty;
         $feeCost = ($buyPrice * $execQty * ($this->feeBps['buy'] ?? 0) / 10000)
             + ($sellPrice * $execQty * ($this->feeBps['sell'] ?? 0) / 10000);
+
         return $gross - $feeCost;
     }
 
     public function passesMinPnl(float $pnlWithBuffers, float $minExpected): bool
     {
         return $pnlWithBuffers >= $minExpected;
+    }
+
+    public function applyMarketConstraints(float $price, float $execQty, array $constraints): array
+    {
+        $qty = $this->roundQty(
+            $execQty,
+            $constraints['step_size'] ?? null,
+            $constraints['pack_size'] ?? null
+        );
+        $price = $this->roundPrice($price, $constraints['tick_size'] ?? null);
+
+        $notional = $price * $qty;
+        if (($constraints['min_notional'] ?? 0) > 0 && $notional < $constraints['min_notional']) {
+            throw new InvalidArgumentException('Order notional below minimum');
+        }
+
+        if (($constraints['max_order_size'] ?? 0) > 0 && $qty > $constraints['max_order_size']) {
+            throw new InvalidArgumentException('Order size exceeds maximum');
+        }
+
+        return ['price' => $price, 'qty' => $qty];
+    }
+
+    private function roundQty(float $qty, ?float $stepSize, ?float $packSize): float
+    {
+        if ($stepSize && $stepSize > 0) {
+            $qty = floor($qty / $stepSize) * $stepSize;
+        }
+        if ($packSize && $packSize > 0) {
+            $qty = floor($qty / $packSize) * $packSize;
+        }
+
+        return $qty;
+    }
+
+    private function roundPrice(float $price, ?float $tickSize): float
+    {
+        return ($tickSize && $tickSize > 0)
+            ? round($price / $tickSize) * $tickSize
+            : $price;
     }
 }

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -29,7 +29,7 @@ class PreflightTest extends TestCase
             constraints: ['tick_size' => 0.5, 'step_size' => 1, 'pack_size' => 5]
         );
 
-        $this->assertEqualsWithDelta(100.5, $result['price'], 0.0000001);
+        $this->assertEqualsWithDelta(100.0, $result['price'], 0.0000001);
         $this->assertEqualsWithDelta(10, $result['qty'], 0.0000001);
     }
 

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -19,4 +19,41 @@ class PreflightTest extends TestCase
         $pnlAfter = $service->expectedNetPnlWithSlippage($legs, $execQty);
         $this->assertFalse($service->passesMinPnl($pnlAfter, 35_000_000));
     }
+
+    public function test_rounds_exec_qty_and_price(): void
+    {
+        $service = new Preflight(feeBps: [], slippageBps: []);
+        $result = $service->applyMarketConstraints(
+            price: 100.3,
+            execQty: 12.7,
+            constraints: ['tick_size' => 0.5, 'step_size' => 1, 'pack_size' => 5]
+        );
+
+        $this->assertEqualsWithDelta(100.5, $result['price'], 0.0000001);
+        $this->assertEqualsWithDelta(10, $result['qty'], 0.0000001);
+    }
+
+    public function test_min_notional_rejection(): void
+    {
+        $service = new Preflight(feeBps: [], slippageBps: []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $service->applyMarketConstraints(
+            price: 100,
+            execQty: 4,
+            constraints: ['tick_size' => 1, 'step_size' => 1, 'min_notional' => 500]
+        );
+    }
+
+    public function test_max_order_size_rejection(): void
+    {
+        $service = new Preflight(feeBps: [], slippageBps: []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $service->applyMarketConstraints(
+            price: 100,
+            execQty: 60,
+            constraints: ['tick_size' => 1, 'step_size' => 1, 'max_order_size' => 50]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- ensure orders respect tick, step, pack sizes before execution
- validate min notional and max size caps
- test rounding and constraint checks

## Testing
- `vendor/bin/pint app/Services/Preflight.php tests/Unit/PreflightTest.php`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68bc42136864832bafa4b3f45cfc714c