### PR TITLE
Use account balances to compute executable quantity

### DIFF
--- a/app/Jobs/ProcessSignalJob.php
+++ b/app/Jobs/ProcessSignalJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Arbitrage\Adapters\ExchangeAdapterFactory;
 use App\Arbitrage\ArbitrageEngine;
+use App\Models\ExchangeAccount;
 use App\Models\PairExchange;
 use App\Models\Signal;
 use App\Services\Preflight;
@@ -17,32 +18,32 @@ class ProcessSignalJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public function __construct(public string $signalId)
-    {
-    }
+    public function __construct(public string $signalId) {}
 
     public function handle(): void
     {
         $signal = Signal::with('legs')->find($this->signalId);
-        if (!$signal || $signal->status !== 'PENDING') {
+        if (! $signal || $signal->status !== 'PENDING') {
             return;
         }
 
         $buyLeg = $signal->legs->firstWhere('side', 'buy');
         $sellLeg = $signal->legs->firstWhere('side', 'sell');
-        if (!$buyLeg || !$sellLeg) {
+        if (! $buyLeg || ! $sellLeg) {
             $signal->update(['status' => 'REJECTED']);
+
             return;
         }
 
-        $buyPx = PairExchange::whereHas('exchange', fn($q) => $q->where('name', $buyLeg->exchange))
-            ->whereHas('pair', fn($q) => $q->where('symbol', $buyLeg->market))
+        $buyPx = PairExchange::whereHas('exchange', fn ($q) => $q->where('name', $buyLeg->exchange))
+            ->whereHas('pair', fn ($q) => $q->where('symbol', $buyLeg->market))
             ->first();
-        $sellPx = PairExchange::whereHas('exchange', fn($q) => $q->where('name', $sellLeg->exchange))
-            ->whereHas('pair', fn($q) => $q->where('symbol', $sellLeg->market))
+        $sellPx = PairExchange::whereHas('exchange', fn ($q) => $q->where('name', $sellLeg->exchange))
+            ->whereHas('pair', fn ($q) => $q->where('symbol', $sellLeg->market))
             ->first();
-        if (!$buyPx || !$sellPx) {
+        if (! $buyPx || ! $sellPx) {
             $signal->update(['status' => 'REJECTED']);
+
             return;
         }
 
@@ -51,24 +52,64 @@ class ProcessSignalJob implements ShouldQueue
             slippageBps: ['buy' => $buyPx->slippage_bps ?? 0, 'sell' => $sellPx->slippage_bps ?? 0]
         );
 
-        $execQty = min($buyLeg->qty, $sellLeg->qty);
+        $buyAccount = ExchangeAccount::where('exchange_id', $buyPx->exchange_id)->first();
+        $sellAccount = ExchangeAccount::where('exchange_id', $sellPx->exchange_id)->first();
+
+        $buyBal = $buyAccount?->balances()->where('currency_id', $buyPx->pair->quote_currency_id)->first();
+        $sellBal = $sellAccount?->balances()->where('currency_id', $sellPx->pair->base_currency_id)->first();
+
+        $balances = [
+            'buy' => (float) ($buyBal->available ?? 0),
+            'sell' => (float) ($sellBal->available ?? 0),
+        ];
+        $reserved = [
+            'buy' => (float) ($buyBal->reserved ?? 0),
+            'sell' => (float) ($sellBal->reserved ?? 0),
+        ];
+        $legDefs = [
+            'buy' => [
+                'side' => 'buy',
+                'price' => (float) $buyLeg->price,
+                'qty' => (float) $buyLeg->qty,
+                'min_notional' => (float) ($buyPx->min_notional ?? 0),
+                'max_qty' => (float) ($buyPx->max_order_size ?? PHP_FLOAT_MAX),
+            ],
+            'sell' => [
+                'side' => 'sell',
+                'price' => (float) $sellLeg->price,
+                'qty' => (float) $sellLeg->qty,
+                'min_notional' => (float) ($sellPx->min_notional ?? 0),
+                'max_qty' => (float) ($sellPx->max_order_size ?? PHP_FLOAT_MAX),
+            ],
+        ];
+
+        $execQty = $preflight->computeExecutableQty($balances, $reserved, $legDefs);
+        $requestedQty = min((float) $buyLeg->qty, (float) $sellLeg->qty);
+        if ($execQty <= 0 || $execQty < $requestedQty) {
+            $signal->update(['status' => 'REJECTED']);
+
+            return;
+        }
+
         $pnl = $preflight->expectedNetPnlWithSlippage([
             'buy' => $buyLeg->price,
             'sell' => $sellLeg->price,
         ], $execQty);
         $min = $signal->constraints['Min_expected_pnl'] ?? 0;
-        if (!$preflight->passesMinPnl($pnl, $min)) {
+        if (! $preflight->passesMinPnl($pnl, $min)) {
             $signal->update(['status' => 'REJECTED', 'expected_pnl' => $pnl]);
+
             return;
         }
 
-        $factory = new ExchangeAdapterFactory();
+        $factory = new ExchangeAdapterFactory;
         $adapters = [];
         foreach ($signal->legs->pluck('exchange')->unique() as $exName) {
             try {
                 $adapters[$exName] = $factory->make($exName);
             } catch (\InvalidArgumentException $e) {
                 $signal->update(['status' => 'REJECTED']);
+
                 return;
             }
         }
@@ -76,16 +117,20 @@ class ProcessSignalJob implements ShouldQueue
         $engine = new ArbitrageEngine($adapters);
         $payload = [
             'constraints' => $signal->constraints ?? [],
-            'legs' => $signal->legs->map(fn($leg) => [
+            'legs' => $signal->legs->map(fn ($leg) => [
                 'symbol' => $leg->market,
                 'side' => $leg->side,
                 'price' => (float) $leg->price,
-                'qty' => (float) $leg->qty,
+                'qty' => $execQty,
                 'tif' => $leg->time_in_force,
                 'exchange' => $leg->exchange,
             ])->toArray(),
         ];
-        $report = $engine->run($payload);
+        $engineBalances = [
+            max(0, $balances['buy'] - $reserved['buy']) / (float) $buyLeg->price,
+            max(0, $balances['sell'] - $reserved['sell']),
+        ];
+        $report = $engine->run($payload, ['balances' => $engineBalances]);
         $signal->update(['status' => $report['status'], 'expected_pnl' => $report['pnl']]);
     }
 }

--- a/tests/Feature/ProcessSignalJobTest.php
+++ b/tests/Feature/ProcessSignalJobTest.php
@@ -213,6 +213,112 @@ class ProcessSignalJobTest extends TestCase
         $this->assertSame('REJECTED', $signal->status);
     }
 
+    public function test_signal_rejected_when_balance_reserved(): void
+    {
+        ExchangeAdapterFactory::reset();
+        $exA = Exchange::create(['name' => 'exA', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $exB = Exchange::create(['name' => 'exB', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $usdt = Currency::create(['symbol' => 'USDT', 'name' => 'Tether']);
+        $irr = Currency::create(['symbol' => 'IRR', 'name' => 'Rial']);
+        $pair = Pair::create(['base_currency_id' => $usdt->id, 'quote_currency_id' => $irr->id, 'symbol' => 'USDT/IRR']);
+        PairExchange::create([
+            'exchange_id' => $exA->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 5,
+            'taker_fee_bps' => 7,
+            'slippage_bps' => 1,
+            'status' => 'ACTIVE',
+        ]);
+        PairExchange::create([
+            'exchange_id' => $exB->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 6,
+            'taker_fee_bps' => 8,
+            'slippage_bps' => 2,
+            'status' => 'ACTIVE',
+        ]);
+
+        $acctA = ExchangeAccount::create([
+            'exchange_id' => $exA->id,
+            'label' => 'a',
+            'api_key_ref' => 'a',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        $acctB = ExchangeAccount::create([
+            'exchange_id' => $exB->id,
+            'label' => 'b',
+            'api_key_ref' => 'b',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        Balance::create([
+            'exchange_account_id' => $acctA->id,
+            'currency_id' => $irr->id,
+            'available' => 20_000_000_000,
+            'reserved' => 0,
+        ]);
+        Balance::create([
+            'exchange_account_id' => $acctA->id,
+            'currency_id' => $usdt->id,
+            'available' => 20_000,
+            'reserved' => 0,
+        ]);
+        Balance::create([
+            'exchange_account_id' => $acctB->id,
+            'currency_id' => $irr->id,
+            'available' => 20_000_000_000,
+            'reserved' => 0,
+        ]);
+        Balance::create([
+            'exchange_account_id' => $acctB->id,
+            'currency_id' => $usdt->id,
+            'available' => 10_000,
+            'reserved' => 9_500,
+        ]);
+
+        $signal = Signal::create([
+            'id' => (string) Str::uuid(),
+            'ttl_ms' => 5000,
+            'status' => 'PENDING',
+            'source' => 'api',
+            'constraints' => ['Min_expected_pnl' => 0],
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exA',
+            'market' => 'USDT/IRR',
+            'side' => 'buy',
+            'price' => 1000000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exB',
+            'market' => 'USDT/IRR',
+            'side' => 'sell',
+            'price' => 1010000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        ProcessSignalJob::dispatchSync($signal->id);
+
+        $signal->refresh();
+        $this->assertSame('REJECTED', $signal->status);
+    }
+
     /**
      * @dataProvider exchangeCombinations
      */

--- a/tests/Feature/ProcessSignalJobTest.php
+++ b/tests/Feature/ProcessSignalJobTest.php
@@ -2,19 +2,21 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
-use Tests\TestCase;
-use App\Models\Signal;
-use App\Models\SignalLeg;
-use App\Models\Exchange;
-use App\Models\Currency;
-use App\Models\Pair;
-use App\Models\PairExchange;
-use App\Jobs\ProcessSignalJob;
 use App\Arbitrage\Adapters\ExchangeAdapterFactory;
 use App\Arbitrage\Adapters\MockBinanceAdapter;
 use App\Arbitrage\Adapters\MockCoinbaseAdapter;
+use App\Jobs\ProcessSignalJob;
+use App\Models\Balance;
+use App\Models\Currency;
+use App\Models\Exchange;
+use App\Models\ExchangeAccount;
+use App\Models\Pair;
+use App\Models\PairExchange;
+use App\Models\Signal;
+use App\Models\SignalLeg;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
 
 class ProcessSignalJobTest extends TestCase
 {
@@ -53,6 +55,35 @@ class ProcessSignalJobTest extends TestCase
             'status' => 'ACTIVE',
         ]);
 
+        $acctA = ExchangeAccount::create([
+            'exchange_id' => $exA->id,
+            'label' => 'a',
+            'api_key_ref' => 'a',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        $acctB = ExchangeAccount::create([
+            'exchange_id' => $exB->id,
+            'label' => 'b',
+            'api_key_ref' => 'b',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        foreach ([$acctA->id, $acctB->id] as $acctId) {
+            Balance::create([
+                'exchange_account_id' => $acctId,
+                'currency_id' => $irr->id,
+                'available' => 20_000_000_000,
+                'reserved' => 0,
+            ]);
+            Balance::create([
+                'exchange_account_id' => $acctId,
+                'currency_id' => $usdt->id,
+                'available' => 20_000,
+                'reserved' => 0,
+            ]);
+        }
+
         $signal = Signal::create([
             'id' => (string) Str::uuid(),
             'ttl_ms' => 5000,
@@ -86,6 +117,100 @@ class ProcessSignalJobTest extends TestCase
         $signal->refresh();
         $this->assertSame('FILLED', $signal->status);
         $this->assertNotNull($signal->expected_pnl);
+    }
+
+    public function test_signal_rejected_when_insufficient_balance(): void
+    {
+        ExchangeAdapterFactory::reset();
+        $exA = Exchange::create(['name' => 'exA', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $exB = Exchange::create(['name' => 'exB', 'api_url' => '', 'ws_url' => '', 'status' => 'ACTIVE']);
+        $usdt = Currency::create(['symbol' => 'USDT', 'name' => 'Tether']);
+        $irr = Currency::create(['symbol' => 'IRR', 'name' => 'Rial']);
+        $pair = Pair::create(['base_currency_id' => $usdt->id, 'quote_currency_id' => $irr->id, 'symbol' => 'USDT/IRR']);
+        PairExchange::create([
+            'exchange_id' => $exA->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 5,
+            'taker_fee_bps' => 7,
+            'slippage_bps' => 1,
+            'status' => 'ACTIVE',
+        ]);
+        PairExchange::create([
+            'exchange_id' => $exB->id,
+            'pair_id' => $pair->id,
+            'exchange_symbol' => 'USDT/IRR',
+            'tick_size' => 1,
+            'step_size' => 1,
+            'min_notional' => 1,
+            'maker_fee_bps' => 6,
+            'taker_fee_bps' => 8,
+            'slippage_bps' => 2,
+            'status' => 'ACTIVE',
+        ]);
+
+        $acctA = ExchangeAccount::create([
+            'exchange_id' => $exA->id,
+            'label' => 'a',
+            'api_key_ref' => 'a',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        $acctB = ExchangeAccount::create([
+            'exchange_id' => $exB->id,
+            'label' => 'b',
+            'api_key_ref' => 'b',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        Balance::create([
+            'exchange_account_id' => $acctA->id,
+            'currency_id' => $irr->id,
+            'available' => 20_000_000_000,
+            'reserved' => 0,
+        ]);
+        Balance::create([
+            'exchange_account_id' => $acctB->id,
+            'currency_id' => $usdt->id,
+            'available' => 1_000,
+            'reserved' => 0,
+        ]);
+
+        $signal = Signal::create([
+            'id' => (string) Str::uuid(),
+            'ttl_ms' => 5000,
+            'status' => 'PENDING',
+            'source' => 'api',
+            'constraints' => ['Min_expected_pnl' => 0],
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exA',
+            'market' => 'USDT/IRR',
+            'side' => 'buy',
+            'price' => 1000000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        SignalLeg::create([
+            'signal_id' => $signal->id,
+            'exchange' => 'exB',
+            'market' => 'USDT/IRR',
+            'side' => 'sell',
+            'price' => 1010000,
+            'qty' => 10000,
+            'time_in_force' => 'IOC',
+        ]);
+
+        ProcessSignalJob::dispatchSync($signal->id);
+
+        $signal->refresh();
+        $this->assertSame('REJECTED', $signal->status);
     }
 
     /**
@@ -123,6 +248,35 @@ class ProcessSignalJobTest extends TestCase
             'slippage_bps' => 2,
             'status' => 'ACTIVE',
         ]);
+
+        $acctA = ExchangeAccount::create([
+            'exchange_id' => $exA->id,
+            'label' => 'a',
+            'api_key_ref' => 'a',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        $acctB = ExchangeAccount::create([
+            'exchange_id' => $exB->id,
+            'label' => 'b',
+            'api_key_ref' => 'b',
+            'is_primary' => true,
+            'created_at' => now(),
+        ]);
+        foreach ([$acctA->id, $acctB->id] as $acctId) {
+            Balance::create([
+                'exchange_account_id' => $acctId,
+                'currency_id' => $irr->id,
+                'available' => 20_000_000_000,
+                'reserved' => 0,
+            ]);
+            Balance::create([
+                'exchange_account_id' => $acctId,
+                'currency_id' => $usdt->id,
+                'available' => 20_000,
+                'reserved' => 0,
+            ]);
+        }
 
         $signal = Signal::create([
             'id' => (string) Str::uuid(),

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -32,4 +32,38 @@ class PreflightTest extends TestCase
         $qty = $service->computeExecutableQty($balances, $reserved, $legs);
         $this->assertSame(5000.0, $qty);
     }
+
+    public function test_compute_executable_qty_rejects_when_min_notional_not_met(): void
+    {
+        $service = new Preflight(feeBps: [], slippageBps: []);
+        $balances = ['buy' => 5];
+        $reserved = ['buy' => 0];
+        $legs = [
+            'buy' => [
+                'side' => 'buy',
+                'price' => 1,
+                'qty' => 10_000,
+                'min_notional' => 10,
+            ],
+        ];
+        $qty = $service->computeExecutableQty($balances, $reserved, $legs);
+        $this->assertSame(0.0, $qty);
+    }
+
+    public function test_compute_executable_qty_respects_max_qty(): void
+    {
+        $service = new Preflight(feeBps: [], slippageBps: []);
+        $balances = ['sell' => 10_000];
+        $reserved = ['sell' => 0];
+        $legs = [
+            'sell' => [
+                'side' => 'sell',
+                'price' => 1,
+                'qty' => 10_000,
+                'max_qty' => 1_000,
+            ],
+        ];
+        $qty = $service->computeExecutableQty($balances, $reserved, $legs);
+        $this->assertSame(1_000.0, $qty);
+    }
 }

--- a/tests/Unit/PreflightTest.php
+++ b/tests/Unit/PreflightTest.php
@@ -19,4 +19,17 @@ class PreflightTest extends TestCase
         $pnlAfter = $service->expectedNetPnlWithSlippage($legs, $execQty);
         $this->assertFalse($service->passesMinPnl($pnlAfter, 35_000_000));
     }
+
+    public function test_compute_executable_qty_considers_balances(): void
+    {
+        $service = new Preflight(feeBps: [], slippageBps: []);
+        $balances = ['buy' => 10_000_000_000, 'sell' => 6_000];
+        $reserved = ['buy' => 0, 'sell' => 1_000];
+        $legs = [
+            'buy' => ['side' => 'buy', 'price' => 1_000_000, 'qty' => 10_000],
+            'sell' => ['side' => 'sell', 'price' => 1_010_000, 'qty' => 10_000],
+        ];
+        $qty = $service->computeExecutableQty($balances, $reserved, $legs);
+        $this->assertSame(5000.0, $qty);
+    }
 }


### PR DESCRIPTION
## Summary
- add `computeExecutableQty` helper to Preflight service
- check balances in ProcessSignalJob and reject signals with insufficient funds
- cover balance-aware logic with unit and feature tests

## Testing
- `vendor/bin/pint --dirty`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68bc420f3640832ba515687a3b644e36